### PR TITLE
Fix/docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ARG BUILD_IMAGE
 ARG GIT_TAG
 ARG GIT_BRANCH
 ARG GIT_REVISION
+ARG ENV_FILE=.env
 
 # fix build problem
 RUN npm config set unsafe-perm true
@@ -28,7 +29,7 @@ COPY coverage ./coverage
 COPY public ./public
 
 COPY vue.config.js ./
-COPY .env .env.${NODE_ENV} ./
+COPY ${ENV_FILE} ./.env
 
 ENV NODE_ENV=${NODE_ENV}
 ENV BUILD_IMAGE=${BUILD_IMAGE}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+# build stage
+FROM node:8.15-alpine as build-stage
+
+ARG NODE_ENV
+ARG BUILD_IMAGE
+ARG GIT_TAG
+ARG GIT_BRANCH
+ARG GIT_REVISION
+
+# fix build problem
+RUN npm config set unsafe-perm true
+
+# install simple http server for serving static content
+RUN npm install -g http-server
+
+# make the 'app' folder the current working directory
+WORKDIR /src
+
+# copy both 'package.json' and 'package-lock.json' (if available)
+COPY package*.json ./
+
+# install project dependencies
+RUN npm install
+
+# copy project files and folders to the current working directory (i.e. 'src' folder)
+COPY src ./src
+COPY coverage ./coverage
+COPY public ./public
+
+COPY vue.config.js ./
+COPY .env .env.${NODE_ENV} ./
+
+ENV NODE_ENV=${NODE_ENV}
+ENV BUILD_IMAGE=${BUILD_IMAGE}
+ENV GIT_TAG=${GIT_TAG}
+ENV GIT_BRANCH=${GIT_BRANCH}
+ENV GIT_REVISION=${GIT_REVISION}
+
+# build app for production with minification
+RUN npm run build
+
+# release build
+FROM nginx:1.13.12-alpine as production-stage
+
+# continued
+COPY --from=build-stage /src/dist /usr/share/nginx/html
+
+COPY default.conf /etc/nginx/conf.d/default.conf
+
+# open port
+EXPOSE 80
+
+# entrypoint
+CMD ["nginx", "-g", "daemon off;"]

--- a/DockerfileDev
+++ b/DockerfileDev
@@ -1,0 +1,13 @@
+FROM node:8.15-alpine
+
+# fix build problem
+RUN npm config set unsafe-perm true
+
+WORKDIR /app
+
+RUN apk add --no-cache git build-base python2
+COPY package.json package-lock.json ./
+
+
+RUN npm install
+ENTRYPOINT ["npm",  "run", "serve"]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BUILD_TAG ?= latest
 BUILD_IMAGE ?= uzhlit/marugoto-frontend
-NODE_ENV ?= test
+NODE_ENV ?= production
+ENV_FILE ?= test
 
 run-dev:
 	BUILD_IMAGE=${BUILD_IMAGE} \
@@ -18,6 +19,7 @@ build:
 	-f Dockerfile \
 	-t ${BUILD_IMAGE}:${BUILD_TAG} \
 	--build-arg NODE_ENV=${NODE_ENV} \
+	--build-arg ENV_FILE=${ENV_FILE} \
 	--build-arg BUILD_IMAGE=${BUILD_IMAGE}:${BUILD_TAG} \
 	--build-arg GIT_TAG=$(shell git describe --tags --abbrev=0 HEAD) \
 	--build-arg GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD) \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+BUILD_TAG ?= latest
+BUILD_IMAGE ?= uzhlit/marugoto-frontend
+NODE_ENV ?= test
+
+run-dev:
+	BUILD_IMAGE=${BUILD_IMAGE} \
+	GIT_TAG=$(shell git describe --tags --abbrev=0 HEAD) \
+	GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD) \
+	GIT_REVISION=$(shell git rev-parse --short HEAD) \
+	PUBLIC_PATH=/ \
+	docker-compose -f docker-compose-dev.yml up --build
+
+run-down:
+	docker-compose -f docker-compose-dev.yml down --remove-orphans
+
+build:
+	docker build \
+	-f Dockerfile \
+	-t ${BUILD_IMAGE}:${BUILD_TAG} \
+	--build-arg NODE_ENV=${NODE_ENV} \
+	--build-arg BUILD_IMAGE=${BUILD_IMAGE}:${BUILD_TAG} \
+	--build-arg GIT_TAG=$(shell git describe --tags --abbrev=0 HEAD) \
+	--build-arg GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD) \
+	--build-arg GIT_REVISION=$(shell git rev-parse --short HEAD) .

--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ npm run lint
 
 ## Docker
 Using Makefile `make build` allow to build a custom image
-using a local env file, that is `env.production` or `env.test`
+using a local env file, forn instance `.env.production.local`
 
 ```
 BUILD_IMAGE=<your namespace>/marugoto-frontend \
-NODE_ENV=local
+NODE_ENV=test \
+ENV_FILE=.env.production.local \
 make build
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,19 @@ npm run build
 ```
 npm run lint
 ```
+
+
+## Docker
+Using Makefile `make build` allow to build a custom image
+using a local env file, that is `env.production` or `env.test`
+
+```
+BUILD_IMAGE=<your namespace>/marugoto-frontend \
+NODE_ENV=local
+make build
+```
+
+Docker can also be used for development purposes (using .env file only)
+```
+BUILD_IMAGE=my-marugo-development make run-dev
+```

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -12,7 +12,6 @@ services:
       - "./public:/app/public"
       - "./babel.config.js:/app/babel.config.js"
       - "./.env:/app/.env"
-      - "./.env.development:/app/.env.development"
       - "./vue.config.js:/app/vue.config.js"
     tty: true
     stdin_open: true

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,25 @@
+version: "3.7"
+services:
+  app:
+    build:
+      context: .
+      dockerfile: DockerfileDev
+    ports:
+      - "8090:8080"
+      - "4020:4020"
+    volumes:
+      - "./src:/app/src"
+      - "./public:/app/public"
+      - "./babel.config.js:/app/babel.config.js"
+      - "./.env:/app/.env"
+      - "./.env.development:/app/.env.development"
+      - "./vue.config.js:/app/vue.config.js"
+    tty: true
+    stdin_open: true
+    environment:
+      CHOKIDAR_USEPOLLING: "true"
+      BUILD_IMAGE: ${BUILD_IMAGE}
+      GIT_TAG: ${GIT_TAG}
+      GIT_BRANCH: ${GIT_BRANCH}
+      GIT_REVISION: ${GIT_REVISION}
+      PUBLIC_PATH: ${PUBLIC_PATH}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "vue-moment": "^4.0.0",
     "vue-router": "^3.0.1",
     "vuex": "^3.0.1",
-    "vuex-persist": "^2.0.0"
+    "vuex-persist": "^2.0.0",
+    "eslint-plugin-vue": "^5.2.3"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.4.1",

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,15 @@ import Clipboard from 'v-clipboard';
 import VueMoment from 'vue-moment'
 import moment from 'moment-timezone'
 
+// eslint-disable-next-line
+console.info('%cMARUGOTO-FRONTEND', 'font-weight: bold',
+  '\n - title:', process.env.VUE_APP_TITLE,
+  '\n - tag:', process.env.VUE_APP_BUILD_IMAGE,
+  '\n - tag:', process.env.VUE_APP_GIT_TAG,
+  '\n - branch:', process.env.VUE_APP_GIT_BRANCH,
+  '\n - revision: ', process.env.VUE_APP_GIT_REVISION,
+)
+
 Vue.config.productionTip = false;
 Vue.use(VCalendar);
 Vue.use(Clipboard);

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,8 @@ import moment from 'moment-timezone'
 // eslint-disable-next-line
 console.info('%cMARUGOTO-FRONTEND', 'font-weight: bold',
   '\n - title:', process.env.VUE_APP_TITLE,
-  '\n - tag:', process.env.VUE_APP_BUILD_IMAGE,
+  '\n - resources:', process.env.VUE_APP_RESOURCES_PATH,
+  '\n - image:', process.env.VUE_APP_BUILD_IMAGE,
   '\n - tag:', process.env.VUE_APP_GIT_TAG,
   '\n - branch:', process.env.VUE_APP_GIT_BRANCH,
   '\n - revision: ', process.env.VUE_APP_GIT_REVISION,

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,9 @@
+process.env.VUE_APP_BUILD_IMAGE = process.env.BUILD_IMAGE || 'uzhli/marugoto-frontend'
+process.env.VUE_APP_GIT_TAG = process.env.GIT_TAG || 'latest'
+process.env.VUE_APP_GIT_BRANCH = process.env.GIT_BRANCH || ''
+process.env.VUE_APP_GIT_REVISION = process.env.GIT_REVISION || ''
+
+
 module.exports = {
     devServer: {
         port: 4020,
@@ -35,5 +41,5 @@ module.exports = {
             .rule('svg-sprite')
             .use('svgo-loader')
             .loader('svgo-loader');
-    }, 
+    },
 };


### PR DESCRIPTION
Hi, after our conversation this morning, I've added a generic Dockerfile that makes use of build-arg to distinguish vue modes (production or test). You can also find a DockerfileDev that make a lot easier the development in previous versions of node.

With Makefile you can specify the docker image and docker tag you want to publish, in our case:

```sh
BUILD_IMAGE=c2dhunilu/marugoto-frontend make build
```

in Makefile:

``` sh
docker build \
	-f Dockerfile \
	-t ${BUILD_IMAGE}:${BUILD_TAG} \
	--build-arg NODE_ENV=${NODE_ENV} \
	--build-arg BUILD_IMAGE=${BUILD_IMAGE}:${BUILD_TAG} \
	--build-arg GIT_TAG=$(shell git describe --tags --abbrev=0 HEAD) \
	--build-arg GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD) \
	--build-arg GIT_REVISION=$(shell git rev-parse --short HEAD) .
```

I made the GIT_TAG, REVISION and BRANCH info are also available in the console:

![Screenshot 2022-07-08 at 16 15 20](https://user-images.githubusercontent.com/1181642/178009862-baffc713-c342-46d6-8fc4-51d5d4b27192.png)



